### PR TITLE
Removed incorrect highlight for ON command

### DIFF
--- a/kos.YAML-tmLanguage
+++ b/kos.YAML-tmLanguage
@@ -58,8 +58,8 @@ patterns:
 - match: \b(?i:(when))\s.+(?i:(then))\b
   name: text.control.kos
   captures:
-    '1': { name: keyword.source.kos }
-    '2': { name: keyword.source.kos }
+    '1': { name: keyword.control.kos }
+    '2': { name: keyword.source.kos  }
 
 - match: \b(?i:add|remove|break|clearscreen|delete|declare( parameter)?|edit|print|remove|run|stage|switch to|toggle|unlock|warp|reboot|shutdown|list|reboot)\b
   name: keyword.source.kos
@@ -79,6 +79,7 @@ patterns:
 
 - match: \b\d+\b
   name: constant.numeric.kos
+  comment: Raw numbers
 
 - begin: \"
   end: \"

--- a/kos.YAML-tmLanguage
+++ b/kos.YAML-tmLanguage
@@ -14,8 +14,9 @@ uuid: a73c33ac-e3fa-45c6-ba20-040413ac4dc4
 patterns:
 - match: //.*
   name: comment.line.source.kos
+  comment: Comments
 
-- match: (?i:add|print|remove|break|clearscreen|copy|delete|declare|edit|list|lock|on|log|rename|remove|run|set|stage|switch|toggle|unlock|reboot|shutdown)\s+[^\.]+$
+- match: (?i:add|print|remove|break|clearscreen|copy|delete|declare|edit|list|lock|log|rename|remove|run|set|stage|switch|toggle|unlock|reboot|shutdown)\s+[^\.]+$
   name: invalid.illegal.source.kos
 
 - match: \b(?i:heading|bearing|direction)\b
@@ -55,7 +56,10 @@ patterns:
       '2': { name: keyword.source.kos }
 
 - match: \b(?i:(when))\s.+(?i:(then))\b
-  name: text.source.kos
+  name: text.control.kos
+  captures:
+    '1': { name: keyword.source.kos }
+    '2': { name: keyword.source.kos }
 
 - match: \b(?i:add|remove|break|clearscreen|delete|declare( parameter)?|edit|print|remove|run|stage|switch to|toggle|unlock|warp|reboot|shutdown|list|reboot)\b
   name: keyword.source.kos
@@ -72,6 +76,9 @@ patterns:
 
 - match: \b(?i:abs|mod|floor|ceiling|round|round|sqrt|sin|cos|tan|arcsin|arccos|arctan|arctan2)\b
   name: support.function.source.kos
+
+- match: \b\d+\b
+  name: constant.numeric.kos
 
 - begin: \"
   end: \"

--- a/kos.YAML-tmLanguage
+++ b/kos.YAML-tmLanguage
@@ -8,7 +8,7 @@
 ---
 name: kOS
 scopeName: source.kos
-fileTypes: [txt, kos]
+fileTypes: [ks]
 uuid: a73c33ac-e3fa-45c6-ba20-040413ac4dc4
 
 patterns:
@@ -21,15 +21,13 @@ patterns:
 
 - match: \b(?i:heading|bearing|direction)\b
   name: storage.type.source.kos
-  captures:
-    '1': { name: keyword.source.kos }
-    '2': { name: keyword.source.kos }
 
-- match: \s*(?i:(set|log|rename))\s.*(?i:(to))\s*
+- match: \s*(?i:(set|log|rename))\s+(?i:\w+)\s+(?i:(to))\s+
   name: text.source.kos
   captures:
     '1': { name: keyword.source.kos }
-    '2': { name: keyword.source.kos }
+    '2': { name: support.variable.kos }
+    '3': { name: keyword.source.kos }
 
 - match: \s*(?i:(copy))\s.*(?i:(to|from))\s*
   name: text.source.kos
@@ -74,12 +72,16 @@ patterns:
 - match: \b(?i:sas|gear|rcs|lights|brakes|legs|chutes|panels) (on|off)\b
   name: support.function.source.kos
 
-- match: \b(?i:abs|mod|floor|ceiling|round|round|sqrt|sin|cos|tan|arcsin|arccos|arctan|arctan2)\b
+- match: \b(?i:min|max|abs|mod|floor|ceiling|round|round|sqrt|sin|cos|tan|arcsin|arccos|arctan|arctan2)\b
   name: support.function.source.kos
 
-- match: \b\d+\b
+- match: \b(\d+(\\.\d+)?)\b
   name: constant.numeric.kos
   comment: Raw numbers
+
+- match: (\+|-|\*|\/|<|>)
+  name: keyword.operator.kos
+  comment: Arithmetic operators
 
 - begin: \"
   end: \"

--- a/kos.tmLanguage
+++ b/kos.tmLanguage
@@ -145,7 +145,7 @@
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>keyword.source.kos</string>
+					<string>keyword.control.kos</string>
 				</dict>
 				<key>2</key>
 				<dict>
@@ -189,6 +189,8 @@
 			<string>support.function.source.kos</string>
 		</dict>
 		<dict>
+			<key>comment</key>
+			<string>Raw numbers</string>
 			<key>match</key>
 			<string>\b\d+\b</string>
 			<key>name</key>

--- a/kos.tmLanguage
+++ b/kos.tmLanguage
@@ -4,13 +4,16 @@
 <dict>
 	<key>fileTypes</key>
 	<array>
-		<string>ks</string>
+		<string>txt</string>
+		<string>kos</string>
 	</array>
 	<key>name</key>
 	<string>kOS</string>
 	<key>patterns</key>
 	<array>
 		<dict>
+			<key>comment</key>
+			<string>Comments</string>
 			<key>match</key>
 			<string>//.*</string>
 			<key>name</key>
@@ -18,7 +21,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(?i:add|print|remove|break|clearscreen|copy|delete|declare|edit|list|lock|on|log|rename|remove|run|set|stage|switch|toggle|unlock|reboot|shutdown)\s+[^\.]+$</string>
+			<string>(?i:add|print|remove|break|clearscreen|copy|delete|declare|edit|list|lock|log|rename|remove|run|set|stage|switch|toggle|unlock|reboot|shutdown)\s+[^\.]+$</string>
 			<key>name</key>
 			<string>invalid.illegal.source.kos</string>
 		</dict>
@@ -56,7 +59,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(?i:(set|log|rename))\s+[\w]+\s+((?i:to))</string>
+			<string>\s*(?i:(set|log|rename))\s.*(?i:(to))\s*</string>
 			<key>name</key>
 			<string>text.source.kos</string>
 		</dict>
@@ -75,7 +78,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(?i:(copy))\s.*(?i:(to|from))</string>
+			<string>\s*(?i:(copy))\s.*(?i:(to|from))\s*</string>
 			<key>name</key>
 			<string>text.source.kos</string>
 		</dict>
@@ -151,13 +154,13 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>\b(?i:(when))\s+.+\s+(?i:(then))\b</string>
+			<string>\b(?i:(when))\s.+(?i:(then))\b</string>
 			<key>name</key>
-			<string>text.source.kos</string>
+			<string>text.control.kos</string>
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(?i:add|remove|break|clearscreen|delete|declare( parameter)?|edit|print|set|remove|run|stage|switch to|toggle|unlock|warp|reboot|shutdown|list|reboot)\b</string>
+			<string>\b(?i:add|remove|break|clearscreen|delete|declare( parameter)?|edit|print|remove|run|stage|switch to|toggle|unlock|warp|reboot|shutdown|list|reboot)\b</string>
 			<key>name</key>
 			<string>keyword.source.kos</string>
 		</dict>
@@ -175,15 +178,21 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(?i:sas|gear|rcs|lights|brakes|legs|chutes|panels) (?i:on|off)\b</string>
+			<string>\b(?i:sas|gear|rcs|lights|brakes|legs|chutes|panels) (on|off)\b</string>
 			<key>name</key>
 			<string>support.function.source.kos</string>
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(?i:abs|mod|min|max|floor|ceiling|round|round|sqrt|sin|cos|tan|arcsin|arccos|arctan|arctan2)\b</string>
+			<string>\b(?i:abs|mod|floor|ceiling|round|round|sqrt|sin|cos|tan|arcsin|arccos|arctan|arctan2)\b</string>
 			<key>name</key>
 			<string>support.function.source.kos</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>\b\d+\b</string>
+			<key>name</key>
+			<string>constant.numeric.kos</string>
 		</dict>
 		<dict>
 			<key>begin</key>

--- a/kos.tmLanguage
+++ b/kos.tmLanguage
@@ -4,8 +4,7 @@
 <dict>
 	<key>fileTypes</key>
 	<array>
-		<string>txt</string>
-		<string>kos</string>
+		<string>ks</string>
 	</array>
 	<key>name</key>
 	<string>kOS</string>
@@ -26,19 +25,6 @@
 			<string>invalid.illegal.source.kos</string>
 		</dict>
 		<dict>
-			<key>captures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>keyword.source.kos</string>
-				</dict>
-				<key>2</key>
-				<dict>
-					<key>name</key>
-					<string>keyword.source.kos</string>
-				</dict>
-			</dict>
 			<key>match</key>
 			<string>\b(?i:heading|bearing|direction)\b</string>
 			<key>name</key>
@@ -55,11 +41,16 @@
 				<key>2</key>
 				<dict>
 					<key>name</key>
+					<string>support.variable.kos</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
 					<string>keyword.source.kos</string>
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>\s*(?i:(set|log|rename))\s.*(?i:(to))\s*</string>
+			<string>\s*(?i:(set|log|rename))\s+(?i:\w+)\s+(?i:(to))\s+</string>
 			<key>name</key>
 			<string>text.source.kos</string>
 		</dict>
@@ -184,7 +175,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(?i:abs|mod|floor|ceiling|round|round|sqrt|sin|cos|tan|arcsin|arccos|arctan|arctan2)\b</string>
+			<string>\b(?i:min|max|abs|mod|floor|ceiling|round|round|sqrt|sin|cos|tan|arcsin|arccos|arctan|arctan2)\b</string>
 			<key>name</key>
 			<string>support.function.source.kos</string>
 		</dict>
@@ -192,9 +183,17 @@
 			<key>comment</key>
 			<string>Raw numbers</string>
 			<key>match</key>
-			<string>\b\d+\b</string>
+			<string>\b(\d+(\\.\d+)?)\b</string>
 			<key>name</key>
 			<string>constant.numeric.kos</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Arithmetic operators</string>
+			<key>match</key>
+			<string>(\+|-|\*|\/|&lt;|&gt;)</string>
+			<key>name</key>
+			<string>keyword.operator.kos</string>
 		</dict>
 		<dict>
 			<key>begin</key>


### PR DESCRIPTION
ON commands were highlighted incorrectly because the ON rule expected a period at the end.

I also added highlighting for numeric literals.